### PR TITLE
effectively switching node versions

### DIFF
--- a/nvmw.bat
+++ b/nvmw.bat
@@ -136,7 +136,7 @@ endlocal
 
 echo Now using Node %1
 set NVMW_CURRENT=%1
-set "PATH=%PATH_ORG%;%NVMW_HOME%;%NVMW_HOME%\%1"
+set "PATH=%NVMW_HOME%;%NVMW_HOME%\%1;%PATH_ORG%"
 exit /b 0
 
 ::===========================================================


### PR DESCRIPTION
If the user is using something other than nvmw it's possible that a different version of node gets picked up before nvmw is added to the path. 
