### PR TITLE
Support number only version

### DIFF
--- a/nvmw.bat
+++ b/nvmw.bat
@@ -143,11 +143,11 @@ if not exist "%NODE_HOME%" (
 
 endlocal
 
-echo Now using Node %1
 set NVMW_CURRENT=%1
 if not %NVMW_CURRENT:~0,1% == v (
   set NVMW_CURRENT=v%1
 )
+echo Now using Node %NVMW_CURRENT%
 set "PATH=%NVMW_HOME%;%NVMW_HOME%\%NVMW_CURRENT%;%PATH_ORG%"
 exit /b 0
 


### PR DESCRIPTION
You can install/uninstall/use with out "v".

``` sh
$ nvmw install 0.10.21
```

It is same as

``` sh
$ nvmw install v0.10.21
```
