### PR TITLE
Support 64-bit Node Install

### DIFF
--- a/nvmw.bat
+++ b/nvmw.bat
@@ -56,7 +56,7 @@ if not %NODE_VERSION:~0,1% == v (
 IF (OS_ARCH==32) (set NODE_EXE_URL=http://nodejs.org/dist/%NODE_VERSION%/node.exe) ELSE (set NODE_EXE_URL=http://nodejs.org/dist/%NODE_VERSION%/x64/node.exe)
 echo Start installing Node %NODE_VERSION% (x%OS_ARCH%)
 
-set "NODE_HOME=%NVMW_HOME%%NODE_VERSION%\x%OS_ARCH%"
+set "NODE_HOME=%NVMW_HOME%%NODE_VERSION%"
 mkdir "%NODE_HOME%"
 set "NODE_EXE_FILE=%NODE_HOME%\node.exe"
 set "NPM_ZIP_FILE=%NODE_HOME%\npm.zip"
@@ -109,7 +109,7 @@ if "%NVMW_CURRENT%" == "%NODE_VERSION%" (
   exit /b 1
 )
 
-set "NODE_HOME=%NVMW_HOME%\%NODE_VERSION%\x%OS_ARCH%"
+set "NODE_HOME=%NVMW_HOME%\%NODE_VERSION%"
 set "NODE_EXE_FILE=%NODE_HOME%\node.exe"
 
 if not exist "%NODE_HOME%" (
@@ -136,7 +136,7 @@ set NODE_VERSION=%1
 if not %NODE_VERSION:~0,1% == v (
   set NODE_VERSION=v%1
 )
-set "NODE_HOME=%NVMW_HOME%%NODE_VERSION%\x%OS_ARCH%"
+set "NODE_HOME=%NVMW_HOME%%NODE_VERSION%"
 
 if not exist "%NODE_HOME%" (
   echo Node %NODE_VERSION% is not installed


### PR DESCRIPTION
This patch detects whether Windows is running on a 32 or 64-bit architecture and sets the node installation path accordingly.
