### PR TITLE
If PROGRAMFILES(x86) is not existed, OS_ARCH is empty, so it is fixed.

### DIFF
--- a/nvmw.bat
+++ b/nvmw.bat
@@ -8,7 +8,12 @@ if not defined PATH_ORG (
   set "PATH_ORG=%PATH%"
 )
 
+set IS64=FALSE
 if exist "%PROGRAMFILES(X86)%" if not "%3" == "x86" (
+  set IS64=TRUE
+)
+
+if %IS64% == TRUE (
   set OS_ARCH=64
 ) else (
   set OS_ARCH=32


### PR DESCRIPTION
occurred error in checking OS_ARCH.
If %PROGRAMFILES(X86)% is not exited, ignore else statement.
so OS_ARCH is empty.


```
if X if Y (
   foo
) else (
  bar
)
```

same as 
```
if X (
  if Y (
     foo
  ) else (
     bar
  )
)

```

therefore not run bar if X is false.

This code is fixed above problem.