### PR TITLE
download progress without scroll, and others

### DIFF
--- a/get_npm.js
+++ b/get_npm.js
@@ -59,6 +59,10 @@ function noNpmAndExit() {
 function downloadNpmZip(version) {
   var uri = util.format(BASE_URL, version);
   wget(uri, function (filename, data) {
+    if (filename === null) {
+        console.error('Can\'t get npm: ' + uri);
+        process.exit(1);
+    }
     fs.writeFile(path.join(targetDir, 'npm.zip'), data, function (err) {
       if (err) {
         return console.error(err.message);

--- a/nvmw.bat
+++ b/nvmw.bat
@@ -137,7 +137,7 @@ set "NODE_EXE_FILE=%NODE_HOME%\%NODE_TYPE%.exe"
 set "NPM_ZIP_FILE=%NODE_HOME%\npm.zip"
 
 if not exist "%NODE_EXE_FILE%" (
-  cscript "%NVMW_HOME%\fget.js" %NODE_EXE_URL% "%NODE_EXE_FILE%"
+  cscript //nologo "%NVMW_HOME%\fget.js" %NODE_EXE_URL% "%NODE_EXE_FILE%"
 )
 
 if not exist "%NODE_EXE_FILE%" (
@@ -151,13 +151,12 @@ if not exist "%NODE_EXE_FILE%" (
   echo Start install npm
 
   "%NODE_EXE_FILE%" "%NVMW_HOME%\get_npm.js" "%NODE_HOME%" "%NODE_TYPE%/%NODE_VERSION%"
-  if not exist %NPM_ZIP_FILE% (
-    exit /b 0;
-  )
+  if not exist "%NPM_ZIP_FILE%" goto install_error
 
   set "CD_ORG=%CD%"
+  %~d0
   cd "%NODE_HOME%"
-  cscript "%NVMW_HOME%\unzip.js" "%NPM_ZIP_FILE%" "%NODE_HOME%"
+  cscript //nologo "%NVMW_HOME%\unzip.js" "%NPM_ZIP_FILE%" "%NODE_HOME%"
   mkdir "%NODE_HOME%\node_modules"
   move npm-* "%NODE_HOME%\node_modules\npm"
   copy "%NODE_HOME%\node_modules\npm\bin\npm.cmd" "%NODE_HOME%\npm.cmd"
@@ -301,8 +300,10 @@ echo Now using %NVMW_CURRENT_TYPE% %NVMW_CURRENT%
 
 if %NVMW_CURRENT_TYPE% == iojs (
   set "PATH=%NVMW_HOME%;%NVMW_HOME%%NVMW_CURRENT_TYPE%\%NVMW_CURRENT%;%PATH_ORG%"
+  set "NODE_PATH=%NVMW_HOME%%NVMW_CURRENT_TYPE%\%NVMW_CURRENT%\node_modules"
 ) else (
   set "PATH=%NVMW_HOME%;%NVMW_HOME%\%NVMW_CURRENT%;%PATH_ORG%"
+  set "NODE_PATH=%NVMW_HOME%\%NVMW_CURRENT%\node_modules"
 )
 
 exit /b 0

--- a/wget.js
+++ b/wget.js
@@ -1,6 +1,7 @@
 var url = require('url'),
     bytes = require('./bytes'),
-    fs = require('fs');
+    fs = require('fs'),
+    ESC_UP_CLL = '\x1B[1A\x1B[K'; // Up + Clear-Line
 
 function wget(uri, callback) {
     console.log('Download file from %s', uri);
@@ -14,6 +15,7 @@ function wget(uri, callback) {
 
     var req = http.get(options, function (res) {
         if (res.statusCode === 302 || res.statusCode === 301) {
+            console.log('Redirect: ' + res.headers.location);
             return wget(res.headers.location, callback);
         }
         if (res.statusCode !== 200) {
@@ -21,12 +23,18 @@ function wget(uri, callback) {
             return;
         }
         var contentLength = parseInt(res.headers['content-length'], 10);
+        if (isNaN(contentLength)) {
+            console.log('Can\'t get \'content-length\'');
+            callback(null);
+            return;
+        }
         console.log('Content length is %s', bytes(contentLength));
 
         var data = new Buffer(contentLength);
         var offset = 0;
 
         var start = Date.now();
+        console.log(''); // New line for ESC_UP_CLL
         res.on('data', function (buf) {
             buf.copy(data, offset);
             offset += buf.length;
@@ -34,7 +42,7 @@ function wget(uri, callback) {
             if (use === 0) {
               use = 1;
             }
-            console.log('Download %d%, %s / %s, %s/s ...',
+            console.log(ESC_UP_CLL + 'Download %d%, %s / %s, %s/s ...',
                 parseInt(offset / contentLength * 100, 10), bytes(offset), bytes(contentLength),
                 bytes(offset / use * 1000));
         });


### PR DESCRIPTION
- `wget.js`: Show the progress without scroll.
- `wget.js`: Check the valid content-length.
- `wget.js`: Show new URL when it's redirected.
- `get_npm.js`: Check the downloaded npm.
- `nvmw.bat`: Hide cscript logo.
- `nvmw.bat`: Exit when npm installing was failed. https://github.com/hakobera/nvmw/issues/38
- `nvmw.bat`: Change current-drive for `move`. https://github.com/hakobera/nvmw/issues/37
- `nvmw.bat`: Set `NODE_PATH` enviroment-valiable.
