### PR TITLE
Persist choice from 'nvmw use [...]'

### DIFF
--- a/nvmw.bat
+++ b/nvmw.bat
@@ -421,7 +421,7 @@ set LINE=%LINE:(=@%
 set LINE=%LINE:)=$%
 set LINE=%LINE:;= %
 ::Removing any path referencing '.nvmw'
-for %%a in (%LINE%) do echo %%a | find /i ".nvmw">NUL || set NEWPATH=!NEWPATH!;%%a
+for %%a in (%LINE%) do echo %%a | %windir%\system32\FIND.exe /i ".nvmw">NUL || set NEWPATH=!NEWPATH!;%%a
 ::If empty we return empty
 if [!NEWPATH!] == [] (
   set PATH_ORG=

--- a/nvmw.bat
+++ b/nvmw.bat
@@ -381,25 +381,9 @@ if not %NVMW_CURRENT_ARCH% == %OS_ARCH% (
 )
 
 setlocal EnableDelayedExpansion
-::Changing special characters
-set LINE=%PATH_ORG%
-set LINE=%LINE: =#%
-set LINE=%LINE:(=@%
-set LINE=%LINE:)=$%
-set LINE=%LINE:;= %
-::Removing any path referencing '.nvmw'
-echo Removing from System Path :
-for %%a in (%LINE%) do echo %%a | find /i ".nvmw" || set NEWPATH=!NEWPATH!;%%a
-::Changing back special characters
-set NEWPATH=!NEWPATH:#= !
-set NEWPATH=!NEWPATH:@=(!
-set NEWPATH=!NEWPATH:$=)!
-::Setting back to PATH_ORG
-set PATH_ORG=!NEWPATH:~1!;
-
+::Set reference paths
 set PATH_IOJS=%NVMW_HOME%%NVMW_CURRENT_TYPE%\%NVMW_CURRENT%%NVMW_CURRENT_ARCH_PADDING%
 set PATH_NODE=%NVMW_HOME%%NVMW_CURRENT%%NVMW_CURRENT_ARCH_PADDING%
-
 if %NVMW_CURRENT_TYPE% == iojs (
   set PATH_TO_SET=%NVMW_HOME%;%PATH_IOJS%
   set NODE_PATH_TO_SET=%PATH_IOJS%\node_modules
@@ -407,18 +391,49 @@ if %NVMW_CURRENT_TYPE% == iojs (
   set PATH_TO_SET=%NVMW_HOME%;%PATH_NODE%
   set NODE_PATH_TO_SET=%PATH_NODE%\node_modules
 )
+set PATH_ORG=
+::Check if PATH key exists in User Path and set it in PATH_ORG
+reg query HKCU\Environment /v PATH>NUL 2>NUL
+if %errorlevel% == 0 (
+  for /f "usebackq tokens=2,*" %%A in (`reg query HKCU\Environment /v PATH`) do set PATH_ORG=%%B
+)
+::Clean User Path
+set RETURN=setUserPath
+goto cleanPath
+:setUserPath
 ::Set for all future sessions
-setx PATH "%PATH_TO_SET%;%PATH_ORG%" /M>NUL
-setx NODE_PATH "%NODE_PATH_TO_SET%" /M>NUL
-::Echo what we're setting back
-echo Adding to System Path :^
-
-!PATH_TO_SET:;=^
-
-!
+setx PATH "%PATH_TO_SET%;%PATH_ORG%">NUL
+setx NODE_PATH "%NODE_PATH_TO_SET%">NUL
+::Clean System Path
+set PATH_ORG=%PATH%
+set RETURN=setPath
+goto cleanPath
+:setPath
 ::Set for the current session
-endlocal & set PATH=%PATH_TO_SET%;%PATH_ORG%  & set NODE_PATH=%NODE_PATH_TO_SET%
+endlocal & set PATH=%PATH_TO_SET%;%PATH_ORG%& set NODE_PATH=%NODE_PATH_TO_SET%
 exit /b 0
+
+:cleanPath
+::Changing special characters
+set LINE=%PATH_ORG%
+set LINE=%LINE: =#%
+set LINE=%LINE:(=@%
+set LINE=%LINE:)=$%
+set LINE=%LINE:;= %
+::Removing any path referencing '.nvmw'
+for %%a in (%LINE%) do echo %%a | find /i ".nvmw">NUL || set NEWPATH=!NEWPATH!;%%a
+::If empty we return empty
+if [!NEWPATH!] == [] (
+  set PATH_ORG=
+  goto %RETURN%
+)
+::Changing back special characters
+set NEWPATH=!NEWPATH:#= !
+set NEWPATH=!NEWPATH:@=(!
+set NEWPATH=!NEWPATH:$=)!
+::Setting back to PATH_ORG
+set PATH_ORG=!NEWPATH:~1!;
+goto %RETURN%
 
 ::===========================================================
 :: ls : List installed versions

--- a/nvmw.bat
+++ b/nvmw.bat
@@ -388,7 +388,7 @@ set LINE=%LINE:(=@%
 set LINE=%LINE:)=$%
 set LINE=%LINE:;= %
 ::Removing any path referencing '.nvmw'
-for %%a in (%LINE%) do echo %%a | find /i "nvmw_fork" || set NEWPATH=!NEWPATH!;%%a
+for %%a in (%LINE%) do echo %%a | find /i ".nvmw" || set NEWPATH=!NEWPATH!;%%a
 ::Changing back special characters
 set NEWPATH=!NEWPATH:#= !
 set NEWPATH=!NEWPATH:@=(!

--- a/nvmw.bat
+++ b/nvmw.bat
@@ -380,14 +380,36 @@ if not %NVMW_CURRENT_ARCH% == %OS_ARCH% (
   set NVMW_CURRENT_ARCH_PADDING=
 )
 
-if %NVMW_CURRENT_TYPE% == iojs (
-  set "PATH=%NVMW_HOME%;%NVMW_HOME%%NVMW_CURRENT_TYPE%\%NVMW_CURRENT%%NVMW_CURRENT_ARCH_PADDING%;%PATH_ORG%"
-  set "NODE_PATH=%NVMW_HOME%%NVMW_CURRENT_TYPE%\%NVMW_CURRENT%%NVMW_CURRENT_ARCH_PADDING%\node_modules"
-) else (
-  set "PATH=%NVMW_HOME%;%NVMW_HOME%\%NVMW_CURRENT%%NVMW_CURRENT_ARCH_PADDING%;%PATH_ORG%"
-  set "NODE_PATH=%NVMW_HOME%\%NVMW_CURRENT%%NVMW_CURRENT_ARCH_PADDING%\node_modules"
-)
+setlocal EnableDelayedExpansion
+::Changing special characters
+set LINE=%PATH_ORG%
+set LINE=%LINE: =#%
+set LINE=%LINE:(=@%
+set LINE=%LINE:)=$%
+set LINE=%LINE:;= %
+::Removing any path referencing '.nvmw'
+for %%a in (%LINE%) do echo %%a | find /i "nvmw_fork" || set NEWPATH=!NEWPATH!;%%a
+::Changing back special characters
+set NEWPATH=!NEWPATH:#= !
+set NEWPATH=!NEWPATH:@=(!
+set NEWPATH=!NEWPATH:$=)!
+::Setting back to PATH_ORG
+set PATH_ORG=!NEWPATH:~1!;
 
+set "PATH_IOJS=%NVMW_HOME%%NVMW_CURRENT_TYPE%\%NVMW_CURRENT%%NVMW_CURRENT_ARCH_PADDING%"
+set "PATH_NODE=%NVMW_HOME%%NVMW_CURRENT%%NVMW_CURRENT_ARCH_PADDING%"
+
+if %NVMW_CURRENT_TYPE% == iojs (
+  set "PATH_TO_SET=%NVMW_HOME%;%PATH_IOJS%"
+) else (
+  set "PATH_TO_SET=%NVMW_HOME%;%PATH_NODE%"
+)
+::Set for the current session
+set "PATH=%PATH_TO_SET%;%PATH_ORG%"
+set "NODE_PATH=%PATH_TO_SET%\node_modules"
+::Set for all future sessions
+setx PATH "%PATH_TO_SET%;%PATH_ORG%" /M
+setx NODE_PATH "%PATH_TO_SET%\node_modules" /M
 exit /b 0
 
 ::===========================================================

--- a/nvmw.bat
+++ b/nvmw.bat
@@ -396,20 +396,19 @@ set NEWPATH=!NEWPATH:$=)!
 ::Setting back to PATH_ORG
 set PATH_ORG=!NEWPATH:~1!;
 
-set "PATH_IOJS=%NVMW_HOME%%NVMW_CURRENT_TYPE%\%NVMW_CURRENT%%NVMW_CURRENT_ARCH_PADDING%"
-set "PATH_NODE=%NVMW_HOME%%NVMW_CURRENT%%NVMW_CURRENT_ARCH_PADDING%"
+set PATH_IOJS=%NVMW_HOME%%NVMW_CURRENT_TYPE%\%NVMW_CURRENT%%NVMW_CURRENT_ARCH_PADDING%
+set PATH_NODE=%NVMW_HOME%%NVMW_CURRENT%%NVMW_CURRENT_ARCH_PADDING%
 
 if %NVMW_CURRENT_TYPE% == iojs (
-  set "PATH_TO_SET=%NVMW_HOME%;%PATH_IOJS%"
+  set PATH_TO_SET=%NVMW_HOME%;%PATH_IOJS%
 ) else (
-  set "PATH_TO_SET=%NVMW_HOME%;%PATH_NODE%"
+  set PATH_TO_SET=%NVMW_HOME%;%PATH_NODE%
 )
-::Set for the current session
-set "PATH=%PATH_TO_SET%;%PATH_ORG%"
-set "NODE_PATH=%PATH_TO_SET%\node_modules"
 ::Set for all future sessions
 setx PATH "%PATH_TO_SET%;%PATH_ORG%" /M>NUL
 setx NODE_PATH "%PATH_TO_SET%\node_modules" /M>NUL
+::Set for the current session
+endlocal & set PATH=%PATH_TO_SET%;%PATH_ORG%  & set NODE_PATH=%NODE_PATH_TO_SET%
 exit /b 0
 
 ::===========================================================

--- a/nvmw.bat
+++ b/nvmw.bat
@@ -408,8 +408,8 @@ if %NVMW_CURRENT_TYPE% == iojs (
 set "PATH=%PATH_TO_SET%;%PATH_ORG%"
 set "NODE_PATH=%PATH_TO_SET%\node_modules"
 ::Set for all future sessions
-setx PATH "%PATH_TO_SET%;%PATH_ORG%" /M
-setx NODE_PATH "%PATH_TO_SET%\node_modules" /M
+setx PATH "%PATH_TO_SET%;%PATH_ORG%" /M>NUL
+setx NODE_PATH "%PATH_TO_SET%\node_modules" /M>NUL
 exit /b 0
 
 ::===========================================================

--- a/nvmw.bat
+++ b/nvmw.bat
@@ -388,6 +388,7 @@ set LINE=%LINE:(=@%
 set LINE=%LINE:)=$%
 set LINE=%LINE:;= %
 ::Removing any path referencing '.nvmw'
+echo Removing from System Path :
 for %%a in (%LINE%) do echo %%a | find /i ".nvmw" || set NEWPATH=!NEWPATH!;%%a
 ::Changing back special characters
 set NEWPATH=!NEWPATH:#= !
@@ -409,6 +410,12 @@ if %NVMW_CURRENT_TYPE% == iojs (
 ::Set for all future sessions
 setx PATH "%PATH_TO_SET%;%PATH_ORG%" /M>NUL
 setx NODE_PATH "%NODE_PATH_TO_SET%" /M>NUL
+::Echo what we're setting back
+echo Adding to System Path :^
+
+!PATH_TO_SET:;=^
+
+!
 ::Set for the current session
 endlocal & set PATH=%PATH_TO_SET%;%PATH_ORG%  & set NODE_PATH=%NODE_PATH_TO_SET%
 exit /b 0

--- a/nvmw.bat
+++ b/nvmw.bat
@@ -401,12 +401,14 @@ set PATH_NODE=%NVMW_HOME%%NVMW_CURRENT%%NVMW_CURRENT_ARCH_PADDING%
 
 if %NVMW_CURRENT_TYPE% == iojs (
   set PATH_TO_SET=%NVMW_HOME%;%PATH_IOJS%
+  set NODE_PATH_TO_SET=%PATH_IOJS%\node_modules
 ) else (
   set PATH_TO_SET=%NVMW_HOME%;%PATH_NODE%
+  set NODE_PATH_TO_SET=%PATH_NODE%\node_modules
 )
 ::Set for all future sessions
 setx PATH "%PATH_TO_SET%;%PATH_ORG%" /M>NUL
-setx NODE_PATH "%PATH_TO_SET%\node_modules" /M>NUL
+setx NODE_PATH "%NODE_PATH_TO_SET%" /M>NUL
 ::Set for the current session
 endlocal & set PATH=%PATH_TO_SET%;%PATH_ORG%  & set NODE_PATH=%NODE_PATH_TO_SET%
 exit /b 0


### PR DESCRIPTION
With these changes `nvmw use [iojs|node]` will persist in system path accross cmd's sessions.
As quickly discussed in #42.

Here are the steps : 
- clean path from special characters
- remove previous `.nvmw` paths
- add back special characters
- determine which iojs or node to get
- set PATH and NODE_PATH in System Path (won't work if System Path is more than 1024 characters, silly windows)
- set PATH and NODE_PATH in current cmd's session

Let me now if this is useful to anyone else.
