### PR TITLE
Fixes the issue of not downloading from the right URL for newer versions of Node.

### DIFF
--- a/nvmw.bat
+++ b/nvmw.bat
@@ -132,9 +132,20 @@ if %NODE_TYPE% == iojs (
   )
 ) else (
   if %ARCH% == x32 (
-    set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/node.exe
+
+    if not %NODE_VERSION:~0,1% == 0 (
+      set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/win-x86/node.exe
+    ) else (
+      set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/node.exe
+    )
   ) else (
-    set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/x64/node.exe
+
+    if not %NODE_VERSION:~0,1% == 0 (
+      set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/win-x64/node.exe
+    ) else (
+      set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/x64/node.exe
+    )
+    
   )
 )
 

--- a/nvmw.bat
+++ b/nvmw.bat
@@ -133,14 +133,14 @@ if %NODE_TYPE% == iojs (
 ) else (
   if %ARCH% == x32 (
 
-    if not %NODE_VERSION:~0,1% == 0 (
+    if not "%NODE_VERSION:~1,1%" == "0" (
       set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/win-x86/node.exe
     ) else (
       set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/node.exe
     )
   ) else (
-
-    if not %NODE_VERSION:~0,1% == 0 (
+    echo HELLO %NODE_VERSION%
+    if not "%NODE_VERSION:~1,1%" == "0" (
       set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/win-x64/node.exe
     ) else (
       set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/x64/node.exe

--- a/nvmw.bat
+++ b/nvmw.bat
@@ -139,7 +139,6 @@ if %NODE_TYPE% == iojs (
       set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/node.exe
     )
   ) else (
-    echo HELLO %NODE_VERSION%
     if not "%NODE_VERSION:~1,1%" == "0" (
       set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/win-x64/node.exe
     ) else (


### PR DESCRIPTION
Still works on older versions. I think this addresses: #61 #60 #58 #59 #57 

Tested installs for x64 latest, 0.12.7, 4.1.1

Thanks for the awesome tool!
