### PR TITLE
Update nvmw.bat

### DIFF
--- a/nvmw.bat
+++ b/nvmw.bat
@@ -132,9 +132,18 @@ if %NODE_TYPE% == iojs (
   )
 ) else (
   if %ARCH% == x32 (
-    set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/node.exe
+	if %NODE_VERSION:~1,1% geq 4 (
+		set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/win-x86/node.exe
+	)else (
+		set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/node.exe
+	)
   ) else (
-    set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/x64/node.exe
+	if %NODE_VERSION:~1,1% geq 4 (
+		set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/win-x64/node.exe
+	)else (
+		set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/x64/node.exe
+	)
+    
   )
 )
 


### PR DESCRIPTION
Small change to nvmw.bat takes into account directory structure changes at nodejs.org for versions greater than 4.

If the version being installed is greater than 4 then the request directory is changed accordingly by adding win-x64 or win-x86 to NODE_EXE_URL variable. This removes 404 error for node versions greater than 4.