### PR TITLE
Update the NODE_EXE_URL of nodejs in nvmw.bat

### DIFF
--- a/nvmw.bat
+++ b/nvmw.bat
@@ -132,9 +132,9 @@ if %NODE_TYPE% == iojs (
   )
 ) else (
   if %ARCH% == x32 (
-    set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/node.exe
+    set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/win-x86/node.exe
   ) else (
-    set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/x64/node.exe
+    set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/win-x64/node.exe
   )
 )
 


### PR DESCRIPTION
the arch parameter of nodejs in "NODE_EXE_URL " is win-32 or win64 instead of 32 or 64.