### PR TITLE
Fix NPM installation by changing target user

### DIFF
--- a/get_npm.js
+++ b/get_npm.js
@@ -41,7 +41,7 @@ if (binType === 'iojs') {
     downloadNpmZip(npmVersion);
   });
 } else {
-  var pkgUri = util.format(NPM_PKG_JSON_URL, 'joyent/node',
+  var pkgUri = util.format(NPM_PKG_JSON_URL, 'nodejs/node',
     binVersion === 'latest' ? 'master' : binVersion);
   wget(pkgUri, function (filename, pkg) {
     if (filename === null) {


### PR DESCRIPTION
Links like https://raw.githubusercontent.com/joyent/node/v7.9.0/deps/npm/package.json are not available anymore. Instead, it's necessary to use https://raw.githubusercontent.com/nodejs/node/v7.9.0/deps/npm/package.json